### PR TITLE
feat: 게시글 완료 시 GitHub Gist 자동 저장 기능 추가

### DIFF
--- a/src/main/java/com/highpass/code_review_ide/gist/dto/GistRequest.java
+++ b/src/main/java/com/highpass/code_review_ide/gist/dto/GistRequest.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 public record GistRequest(
         @NotBlank String title,
         @NotBlank String content,
-        String description
+        String description,
+        String language
 ) {
 }

--- a/src/main/java/com/highpass/code_review_ide/post/api/dto/response/CompletePostResponse.java
+++ b/src/main/java/com/highpass/code_review_ide/post/api/dto/response/CompletePostResponse.java
@@ -7,6 +7,7 @@ import com.highpass.code_review_ide.post.domain.PostStatus;
 public record CompletePostResponse(
         Long postId,
         PostStatus status,
-        LocalDateTime completedAt
+        LocalDateTime completedAt,
+        String gistUrl
 ) {
 }


### PR DESCRIPTION
## PR 작성 수칙
1. 본문 상단에 변경 이유 또는 스크린샷 필수.
2. 관련 이슈가 있으면 반드시 `closes #번호` 또는 `fixes #번호` 사용.
3. 여러 이슈를 한 PR에서 해결할 때는 쉼표로 구분.
4. 아직 완전 해결이 아닌 경우 `partially fixes #번호` 사용.

## #️⃣ 연관된 이슈
close: #27



## 📝 작업 내용

- 게시글 완료(complete) 시 작성자가 GitHub 연동 유저인 경우 Gist에 코드 저장
- Gist 생성 시 언어별 파일 확장자 자동 적용 로직 추가
- 완료 응답(CompletePostResponse)에 gistUrl 필드 추가
- 일반 유저(GitHub 미연동) 및 Gist 저장 실패 시에도 게시글 완료는 정상 처리되도록 구현



## 🖼 스크린샷

이미지



## 💬 리뷰 요구사항

> 리뷰어에게 남기고 싶은 말) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
